### PR TITLE
Remove redundant endpoint callback in _lzReceive as per #7

### DIFF
--- a/src/Fraxiversary.sol
+++ b/src/Fraxiversary.sol
@@ -1080,13 +1080,6 @@ contract Fraxiversary is
         _setTokenURI(tokenId, tokenUri);
         isNonTransferrable[tokenId] = isSoulbound;
 
-        bytes32 composeFrom = ONFTComposeMsgCodec.addressToBytes32(address(this));
-        bytes memory composeInnerMsg = abi.encode(tokenUri, isSoulbound);
-        bytes memory composeMsg = abi.encodePacked(composeFrom, composeInnerMsg);
-
-        bytes memory composedMsgEncoded = ONFTComposeMsgCodec.encode(_origin.nonce, _origin.srcEid, composeMsg);
-        endpoint.sendCompose(toAddress, _guid, 0, composedMsgEncoded);
-
         emit ONFTReceived(_guid, _origin.srcEid, toAddress, tokenId);
     }
 


### PR DESCRIPTION
This pull request removes the logic for composing and sending a message via the `endpoint.sendCompose` function in the `Fraxiversary` contract. The code that handled message encoding and sending upon receiving an ONFT is no longer executed, which streamlines the function and reduces side effects.

- **Message composition and sending removed:**
  - Eliminated the creation of a compose message using `ONFTComposeMsgCodec` and the subsequent call to `endpoint.sendCompose`. This simplifies the contract's logic when handling received ONFTs.